### PR TITLE
allow for dirs/paths with whitespace

### DIFF
--- a/lib/dashd.py
+++ b/lib/dashd.py
@@ -13,11 +13,11 @@ import json
 import sys
 
 def rpc_command(params):
-    dashcmd = config.dashd_path + " --datadir=" + config.datadir
-    
-    #print "'%s' '%s'" % (dashcmd, params)
+    dashcmd = [ config.dash_cli , "--datadir=%s" % config.datadir , params ]
 
-    proc = subprocess.Popen(dashcmd + " " + params, shell=True, bufsize=1, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+    # print "dashcmd = [%s]" % (' '.join(dashcmd))
+
+    proc = subprocess.Popen(dashcmd, bufsize=1, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
     output = ""
     while (True):
         # Read line from stdout, break if EOF reached, append line to output


### PR DESCRIPTION
In case of paths with whitespace (such as "/Users/name/Library/Application Support/DashCore"), the current solution breaks on the first whitespace.

By using a list of arguments, it prevents whitespace from becoming an issue. Also removing shell=True (which isn't needed with this change) will eliminate a potential security risk.